### PR TITLE
[#36] [FEATURE] 응급실 지도 API 구현

### DIFF
--- a/ea-application/app-api/src/main/java/com/nbe2/api/emergencyroom/EmergencyRoomApi.java
+++ b/ea-application/app-api/src/main/java/com/nbe2/api/emergencyroom/EmergencyRoomApi.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
+import com.nbe2.api.emergencyroom.dto.EmergencyRoomMapResponse;
 import com.nbe2.api.emergencyroom.dto.RealTimeEmergencyRoomResponse;
 import com.nbe2.api.global.dto.Response;
 import com.nbe2.domain.emergencyroom.Coordinate;
@@ -40,10 +41,23 @@ public class EmergencyRoomApi {
     }
 
     @GetMapping("/search")
-    public Response<List<String>> saveSearEmergency(
-            @RequestParam("hospitalName") String hospitalName) {
+    public Response<List<String>> saveSearEmergency(@RequestParam String hospitalName) {
         List<String> emergencyRoomListForName =
                 emergencyRoomService.getEmergencyRoomListForName(hospitalName);
         return Response.success(emergencyRoomListForName);
+    }
+
+    @GetMapping("/map")
+    public Response<List<EmergencyRoomMapResponse>> getEmergencyRooms(
+            @RequestParam Double longitude,
+            @RequestParam Double latitude,
+            @RequestParam Double distance) {
+        List<EmergencyRoomMapResponse> responses =
+                emergencyRoomService
+                        .getEmergencyRooms(Coordinate.of(longitude, latitude), distance)
+                        .stream()
+                        .map(EmergencyRoomMapResponse::from)
+                        .toList();
+        return Response.success(responses);
     }
 }

--- a/ea-application/app-api/src/main/java/com/nbe2/api/emergencyroom/dto/EmergencyRoomMapResponse.java
+++ b/ea-application/app-api/src/main/java/com/nbe2/api/emergencyroom/dto/EmergencyRoomMapResponse.java
@@ -1,0 +1,30 @@
+package com.nbe2.api.emergencyroom.dto;
+
+import com.nbe2.domain.emergencyroom.EmergencyRoomMapInfo;
+
+public record EmergencyRoomMapResponse(
+        Long emergencyRoomId,
+        String hpId,
+        String hospitalName,
+        String address,
+        String simpleMap,
+        double longitude,
+        double latitude,
+        double distance) {
+
+    public static EmergencyRoomMapResponse from(EmergencyRoomMapInfo mapInfo) {
+        return new EmergencyRoomMapResponse(
+                mapInfo.emergencyRoomId(),
+                mapInfo.hpId(),
+                mapInfo.hospitalName(),
+                mapInfo.address(),
+                mapInfo.simpleMap(),
+                mapInfo.coordinate().getLongitude(),
+                mapInfo.coordinate().getLatitude(),
+                convertToKilometers(mapInfo.distance()));
+    }
+
+    private static double convertToKilometers(double distanceInMeters) {
+        return Math.round((distanceInMeters / 1000) * 100) / 100.0;
+    }
+}

--- a/ea-domain/build.gradle
+++ b/ea-domain/build.gradle
@@ -6,10 +6,17 @@ dependencies {
 
     implementation project(":ea-common")
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    
 
     // QueryDsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api:'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+
+
+    // 공간 좌표 데이터 관련
+    implementation group: 'org.hibernate.orm', name: 'hibernate-spatial', version: '6.4.1.Final'
+
 }

--- a/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/EmergencyRoomInfo.java
+++ b/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/EmergencyRoomInfo.java
@@ -25,6 +25,15 @@ public record EmergencyRoomInfo(
         int operatingRoomBedCount) {
 
     public EmergencyRoom toEmergencyRoom() {
+
+        Coordinate coordinate;
+
+        if (Double.parseDouble(longitude) < 90.0) {
+            coordinate = Coordinate.of(Double.parseDouble(latitude), Double.parseDouble(longitude));
+        } else {
+            coordinate = Coordinate.of(Double.parseDouble(longitude), Double.parseDouble(latitude));
+        }
+
         return EmergencyRoom.builder()
                 .hpId(id)
                 .hospitalName(hospitalName)
@@ -34,8 +43,7 @@ public record EmergencyRoomInfo(
                 .emergencyRoomContactNumber(emergencyRoomContactNumber)
                 .simpleMap(simpleMap)
                 .emergencyRoomAvailability(emergencyRoomAvailability)
-                .longitude(longitude)
-                .latitude(latitude)
+                .coordinate(coordinate)
                 .medicalDepartments(medicalDepartments)
                 .totalBedCount(totalBedCount)
                 .thoracicIcuBedCount(thoracicIcuBedCount)

--- a/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/EmergencyRoomMapInfo.java
+++ b/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/EmergencyRoomMapInfo.java
@@ -1,0 +1,34 @@
+package com.nbe2.domain.emergencyroom;
+
+import org.locationtech.jts.geom.Point;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record EmergencyRoomMapInfo(
+        Long emergencyRoomId,
+        String hpId,
+        String hospitalName,
+        String address,
+        String simpleMap,
+        Coordinate coordinate,
+        double distance) {
+
+    @QueryProjection
+    public EmergencyRoomMapInfo(
+            Long emergencyRoomId,
+            String hpId,
+            String hospitalName,
+            String address,
+            String simpleMap,
+            Point location,
+            double distance) {
+        this(
+                emergencyRoomId,
+                hpId,
+                hospitalName,
+                address,
+                simpleMap,
+                Coordinate.of(location.getX(), location.getY()),
+                distance);
+    }
+}

--- a/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/EmergencyRoomReader.java
+++ b/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/EmergencyRoomReader.java
@@ -25,4 +25,8 @@ public class EmergencyRoomReader {
                 .map(EmergencyRoom::getHpId)
                 .toList();
     }
+
+    public List<EmergencyRoomMapInfo> read(Coordinate coordinate, double distance) {
+        return emergencyRoomRepository.findByCoordinateAndDistance(coordinate, distance);
+    }
 }

--- a/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/EmergencyRoomRepository.java
+++ b/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/EmergencyRoomRepository.java
@@ -5,7 +5,8 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface EmergencyRoomRepository extends JpaRepository<EmergencyRoom, Long> {
+public interface EmergencyRoomRepository
+        extends JpaRepository<EmergencyRoom, Long>, EmergencyRoomRepositoryCustom {
 
     List<EmergencyRoom> findByHospitalNameContaining(String name);
 

--- a/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/EmergencyRoomRepositoryCustom.java
+++ b/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/EmergencyRoomRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.nbe2.domain.emergencyroom;
+
+import java.util.List;
+
+public interface EmergencyRoomRepositoryCustom {
+
+    List<EmergencyRoomMapInfo> findByCoordinateAndDistance(Coordinate coordinate, double distance);
+}

--- a/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/EmergencyRoomRepositoryImpl.java
+++ b/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/EmergencyRoomRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.nbe2.domain.emergencyroom;
+
+import static com.nbe2.domain.emergencyroom.EmergencyRoom.*;
+import static com.nbe2.domain.emergencyroom.QEmergencyRoom.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+@Repository
+@RequiredArgsConstructor
+public class EmergencyRoomRepositoryImpl implements EmergencyRoomRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<EmergencyRoomMapInfo> findByCoordinateAndDistance(
+            Coordinate coordinate, double distance) {
+        NumberTemplate<Double> calculatedDistance = getCalculatedDistance(coordinate);
+
+        return queryFactory
+                .select(
+                        new QEmergencyRoomMapInfo(
+                                emergencyRoom.id, // 필요한 필드만 선택
+                                emergencyRoom.hpId,
+                                emergencyRoom.hospitalName,
+                                emergencyRoom.address,
+                                emergencyRoom.simpleMap,
+                                emergencyRoom.location,
+                                calculatedDistance))
+                .from(emergencyRoom)
+                .where(calculatedDistance.loe(distance))
+                .orderBy(calculatedDistance.asc())
+                .fetch();
+    }
+
+    private static NumberTemplate<Double> getCalculatedDistance(Coordinate coordinate) {
+        return Expressions.numberTemplate(
+                Double.class,
+                "ST_Distance_Sphere({0}, {1})",
+                emergencyRoom.location,
+                coordinateToPoint(coordinate));
+    }
+}

--- a/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/EmergencyRoomService.java
+++ b/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/EmergencyRoomService.java
@@ -32,4 +32,8 @@ public class EmergencyRoomService {
     public List<String> getEmergencyRoomListForName(String name) {
         return emergencyRoomReader.readByHospitalName(name);
     }
+
+    public List<EmergencyRoomMapInfo> getEmergencyRooms(Coordinate coordinate, double distance) {
+        return emergencyRoomReader.read(coordinate, distance);
+    }
 }

--- a/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/exception/EmergencyRoomErrorCode.java
+++ b/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/exception/EmergencyRoomErrorCode.java
@@ -11,6 +11,7 @@ import com.nbe2.common.exception.ErrorReason;
 public enum EmergencyRoomErrorCode implements BaseErrorCode {
     REGION_NOT_FOUND_ERROR(BAD_REQUEST, "EMR_400_1", "좌표에 해당하는 지역을 찾을 수 없습니다"),
     EMERGENCY_ROOM_NOT_FOUND_ERROR(BAD_REQUEST, "EMR_400_2", "해당 ID의 응급실 정보가 없습니다"),
+    INVALID_COORDINATE(BAD_REQUEST, "EMR_400_4", "유효하지 않은 좌표입니다"),
     REAL_TIME_EMERGENCY_ROOM_INFO_NOT_FOUND_ERROR(
             BAD_REQUEST, "EMR_400_3", "해당 ID의 실시간 응급실 정보가 없습니다"),
     ;

--- a/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/exception/InvalidCoordinateException.java
+++ b/ea-domain/src/main/java/com/nbe2/domain/emergencyroom/exception/InvalidCoordinateException.java
@@ -1,0 +1,12 @@
+package com.nbe2.domain.emergencyroom.exception;
+
+import com.nbe2.common.exception.DomainException;
+
+public class InvalidCoordinateException extends DomainException {
+
+    public static final InvalidCoordinateException EXCEPTION = new InvalidCoordinateException();
+
+    private InvalidCoordinateException() {
+        super(EmergencyRoomErrorCode.INVALID_COORDINATE);
+    }
+}

--- a/ea-domain/src/main/resources/application-domain.yml
+++ b/ea-domain/src/main/resources/application-domain.yml
@@ -1,0 +1,38 @@
+spring:
+  jpa:
+    open-in-view: false
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:mysql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?useSSL=false&allowPublicKeyRetrieval=true
+    username: ${DATABASE_USER}
+    password: ${DATABASE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show-sql: true
+        format_sql: true
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+  datasource:
+    url: jdbc:mysql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?useSSL=false&allowPublicKeyRetrieval=true
+    username: ${DATABASE_USER}
+    password: ${DATABASE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show-sql: true
+        format_sql: true

--- a/ea-infra/build.gradle
+++ b/ea-infra/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     implementation project(':ea-domain')
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    runtimeOnly 'com.mysql:mysql-connector-j'
 
     //open feign
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.1.3'

--- a/ea-infra/src/main/resources/application-infra.yml
+++ b/ea-infra/src/main/resources/application-infra.yml
@@ -10,22 +10,9 @@ spring:
   config:
     activate:
       on-profile: local
-  datasource:
-    url: jdbc:mysql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?useSSL=false&allowPublicKeyRetrieval=true
-    username: ${DATABASE_USER}
-    password: ${DATABASE_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
-  jpa:
-    hibernate:
-      ddl-auto: create
-    properties:
-      hibernate:
-        show-sql: true
-        format_sql: true
 redis:
   host: localhost
   port: 6379
-
 logging:
   level:
     org:
@@ -44,18 +31,6 @@ spring:
   config:
     activate:
       on-profile: dev
-  datasource:
-    url: jdbc:mysql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?useSSL=false&allowPublicKeyRetrieval=true
-    username: ${DATABASE_USER}
-    password: ${DATABASE_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
-  jpa:
-    hibernate:
-      ddl-auto: update
-    properties:
-      hibernate:
-        show-sql: true
-        format_sql: true
 redis:
   host: ${REDIS_HOST}
   port: ${REDIS_PORT}


### PR DESCRIPTION
- 사용자의 현재 좌표와 반경을 받아서 해당 좌표의 해당 반경내의 응글실들을 조회

<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

<!-- Auto close 할 이슈 번호 -->
- close #36

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

- JPA 관련 설정은 domain 모듈에 있는게 맞는거 같아서 도메인 모듈로 옮겼습니다
- JPA 공간좌표관련 의존성 추가할게있어서 추가했습니다
- 좌표와 반경을 파라미터로 받아 좌표의 해당 반경내의 응급실들을 조회합니다.

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->

도메인 모듈에서 JPA 관련 의존성을 허용하니 이게 점점 의존성이 조금씩 더 들어가게되고 점점 모듈을 분리한 의미가 퇴색되어가는 느낌이 듭니다...ㅠㅠ

리팩토링할떄 도메인 모듈에서 완전히 의존성을 지워보는 작업을 제안해봅니다!
